### PR TITLE
Noticed a surprising number of misspellings.

### DIFF
--- a/lib/cPanel/TaskQueue.pm
+++ b/lib/cPanel/TaskQueue.pm
@@ -109,7 +109,7 @@ sub _valid_serializer {
 
 sub _get_serializer {
     unless ( defined $the_serializer ) {
-        eval 'use cPanel::TQSerializer::Storable;';    ## no crititc (ProhibitStringyEval)
+        eval 'use cPanel::TQSerializer::Storable;';    ## no critic(ProhibitStringyEval)
         cPanel::StateFile->_throw(@_) if $@;
         $the_serializer = 'cPanel::TQSerializer::Storable';
     }

--- a/lib/cPanel/TaskQueue.pod
+++ b/lib/cPanel/TaskQueue.pod
@@ -19,7 +19,7 @@ This document describes cPanel::TaskQueue version 0.606
     # Processing loop
     while (1) {
         # if work, process, else sleep
-        if ( $queue-has_work_to_do() ) {
+        if ( $queue->has_work_to_do() ) {
             eval { $queue->process_next_task() };
             if ( $@ ) {
                 Carp::carp( $@ );
@@ -121,7 +121,7 @@ The command type must have been registered with the TaskQueue module.
 
 =item Command must not duplicate a command already in the queue.
 
-Each command type can have it's own definition of duplicate. It can depend on
+Each command type can have its own definition of duplicate. It can depend on
 one or more of the arguments or not.
 
 =back
@@ -217,7 +217,7 @@ returned.
 Does the specified I<uuid> reference a task in the queue?
 
 Because of the nature of a task queue, the particular I<uuid> tested may be scheduled
-for processsing immediately after the test. Therefore, a true answer is not as useful as
+for processing immediately after the test. Therefore, a true answer is not as useful as
 it might seem. A false answer does tell us that the item is no longer waiting.
 
 =item $q->find_task( $uuid )
@@ -267,7 +267,7 @@ empty.
 Does the specified I<uuid> reference a task currently being processed?
 
 Because of the nature of a task queue, the particular I<uuid> tested may be scheduled
-for processsing or finish processing immediately after the test. I'm not sure if this
+for processing or finish processing immediately after the test. I'm not sure if this
 test is actually useful for anything.
 
 =item $q->is_task_deferred( $uuid )
@@ -275,7 +275,7 @@ test is actually useful for anything.
 Does the specified I<uuid> reference a task that is currently deferred?
 
 Because of the nature of a task queue, the particular I<uuid> tested may be scheduled
-for processsing or finish processing immediately after the test. I'm not sure if this
+for processing or finish processing immediately after the test. I'm not sure if this
 test is actually useful for anything.
 
 =item $q->how_many_deferred()
@@ -308,7 +308,7 @@ of the state of the queue.
 
 Prevent any more tasks from moving from the waiting state into the processing
 state. This does not stop any tasks from processing once they begin processing.
-If the queue is paused, no more tasks will move from the waitig state to the
+If the queue is paused, no more tasks will move from the waiting state to the
 processing state.
 
 =item $q->resume_processing()

--- a/lib/cPanel/TaskQueue/ChildProcessor.pod
+++ b/lib/cPanel/TaskQueue/ChildProcessor.pod
@@ -1,11 +1,11 @@
 
 =head1  NAME
 
-    cPanel::TaskQueue::ChildProcessor - Processes an individual task from the cPanel::TaskQueue in a child process.
+cPanel::TaskQueue::ChildProcessor - Processes an individual task from the cPanel::TaskQueue in a child process.
 
 =head1 VERSION
 
-    This document describes cPanel::TaskQueue::ChildProcessor version 0.606.
+This document describes cPanel::TaskQueue::ChildProcessor version 0.606.
 
 =head1 SYNOPSIS
 
@@ -37,12 +37,12 @@
 
 =head1  DESCRIPTION
 
-    This module provides an abstraction for commands to be executed by a child
-    process launched from the TaskQueue. It overrides the C<process_task> method
-    to fork a child process and return the appropriate information back to
-    C<cPanel::TaskQueue>.
+This module provides an abstraction for commands to be executed by a child
+process launched from the TaskQueue. It overrides the C<process_task> method
+to fork a child process and return the appropriate information back to
+C<cPanel::TaskQueue>.
 
-    In addition, the class provides automatic timeout support for the child process.
+In addition, the class provides automatic timeout support for the child process.
 
 =head1 PUBLIC METHODS
 

--- a/lib/cPanel/TaskQueue/Cookbook.pod
+++ b/lib/cPanel/TaskQueue/Cookbook.pod
@@ -1,6 +1,6 @@
 =head1 NAME
 
-cPanel::TaskQueue::Recipes - some tasty uses of the cPanel::TaskQueue modules.
+cPanel::TaskQueue::Cookbook - some tasty uses of the cPanel::TaskQueue modules.
 
 =head1 DESCRIPTION
 
@@ -392,7 +392,7 @@ Sometimes a command may invalidate the need for other commands in the queue. For
 example, a command to restart a server is not very useful if a command to shut
 down the server is in the queue behind it. To provide the ability to remove
 commands that have previously been queued in favor of a new command, you can
-override the C<overrides> method of C<cPanell:TaskQueue::Processor>.
+override the C<overrides> method of C<cPanel::TaskQueue::Processor>.
 
 For example, let's say we have a special feature in the I<notify> command to
 send a message to I<ALL>. This should obviously override a notification to any
@@ -715,7 +715,7 @@ This loop is somewhat more complicated due to the need to service the
 C<Scheduler> in a timely fashion. Any time we don't have something to process,
 we want to sleep the lesser of the default wait time and the time until the
 next scheduled event. We also want to schedule C<Task>s as soon as they are
-ready. It's also important to check the C<Scheduler> on every pass through
+ready. It is also important to check the C<Scheduler> on every pass through
 the loop, otherwise a series of long-running C<Task>s could prevent us from
 scheduling C<Task>s that are now ready.
 

--- a/lib/cPanel/TaskQueue/Ctrl.pod
+++ b/lib/cPanel/TaskQueue/Ctrl.pod
@@ -3,7 +3,6 @@
 
 cPanel::TaskQueue::Ctrl - A text-based interface for controlling a TaskQueue
 
-
 =head1 VERSION
 
 This document describes cPanel::TaskQueue::Ctrl version 0.606
@@ -199,7 +198,7 @@ serialization method on subsequent attempts to create the queue and scheduler.
 
 =head2 display_queue_info( $ctrl, $fh, $queue, $sched )
 
-Write general infomration about the TaskQueue and Scheduler to the supplied
+Write general information about the TaskQueue and Scheduler to the supplied
 filehandle. The information includes the serialization type, and the full names
 of the state files for C<$queue> and C<$sched> objects.
 

--- a/lib/cPanel/TaskQueue/PluginManager.pod
+++ b/lib/cPanel/TaskQueue/PluginManager.pod
@@ -115,7 +115,7 @@ module provides.
 
 C<load_all_plugins> was called without a I<directories> parameter.
 
-=item C<< No namepsace list supplied. >>
+=item C<< No namespace list supplied. >>
 
 C<load_all_plugins> was called without a I<namespaces> parameter.
 
@@ -174,7 +174,7 @@ variables.
 
 =head1 DEPENDENCIES
 
-cPanel::TaskQeue
+cPanel::TaskQueue
 
 =head1 SEE ALSO
 

--- a/lib/cPanel/TaskQueue/Scheduler.pod
+++ b/lib/cPanel/TaskQueue/Scheduler.pod
@@ -154,7 +154,7 @@ is returned.
 Does the specified I<uuid> reference a task to be scheduled?
 
 Because of the nature of a task scheduler, the particular I<uuid> tested may
-be scheduled for processsing immediately after the test. Therefore, a true answer
+be scheduled for processing immediately after the test. Therefore, a true answer
 is not as useful as it might seem. A false answer does tell us that the item is
 no longer waiting.
 
@@ -164,7 +164,7 @@ Returns the time (in epoch seconds) when the Task referenced by I<uuid> is
 scheduled to be run or C<undef> if I<uuid> does not reference a valid task.
 
 Because of the nature of a task scheduler, the particular I<uuid> tested may
-be scheduled for processsing immediately after the test.
+be scheduled for processing immediately after the test.
 
 =item $s->how_many_scheduled()
 
@@ -183,7 +183,7 @@ C<undef> if there are no tasks to process.
 
 =item $s->snapshot_task_schedule()
 
-Returns an array reference containing a series of hashes continaing the I<time>
+Returns an array reference containing a series of hashes containing the I<time>
 a task is scheduled to run and a copy of the I<task> to run at that time. The
 first item in the array is guaranteed to be the next task to run. The order of
 the rest of the list is not guaranteed.
@@ -347,7 +347,7 @@ Some other file has already set the policies.
 
 =item C<< Unrecognized policy '%s' >>
 
-The only policy supported by C<Cpane::TaskQueue::Scheduler> is I<-logger>.
+The only policy supported by C<cPanel::TaskQueue::Scheduler> is I<-logger>.
 
 =back
 

--- a/lib/cPanel/TaskQueue/Task.pod
+++ b/lib/cPanel/TaskQueue/Task.pod
@@ -40,7 +40,7 @@ contain spaces, surround it with quotes.
 
 =item I<nsid>
 
-A namespace string used to generate a unique identifer for the Task. Must be a
+A namespace string used to generate a unique identifier for the Task. Must be a
 non-empty string containing no ':' characters. Defaults to an internal UUID.
 
 =item I<id>
@@ -85,10 +85,10 @@ Create a deep copy of the C<cPanel::TaskQueue::Task> object.
 
 =item $q->mutate( $hashref )
 
-Clone the C<cPanel::TaskQueue::Task> object and modify some of its properites.
+Clone the C<cPanel::TaskQueue::Task> object and modify some of its properties.
 
 The C<mutate> method supports hashref argument that contains small number of
-named parameters for changing the assocatiated properties.
+named parameters for changing the associated properties.
 
 =over 4
 
@@ -208,7 +208,7 @@ The C<new> method was called with no hash ref to initialize the object state.
 =item C<< Args parameter must be a hash ref. >>
 
 Incorrect parameter type for C<new> method. Probably called the method with either positional arguments
-or with named arguments outside an anonynmous hash.
+or with named arguments outside an anonymous hash.
 
 =item C<< Missing command string. >>
 


### PR DESCRIPTION
While going over this code with David Nielson and Trinity Quirk in
training, I spotted an annoying typo. Trinity started pointing out more
as we moved through the docs.

Conflicts:

```
lib/cPanel/TaskQueue.pod
lib/cPanel/TaskQueue/ChildProcessor.pod
```
