### PR TITLE
Add support for flushing and deleting tasks.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,12 @@
 Revision history for cPanel-TaskQueue
 
 {{$NEXT}}
+     - Add ability to flush all scheduled tasks to the waiting queue, whether
+       or not they have reached their scheduled time.
+     - Add the ability to delete all scheduled tasks.
+     - Corrected handling of optional --serial parameter in taskqueuectl.
+     - Added flush_scheduled_tasks to Ctrl logic to support the new
+       functionality.
 0.606     2014-02-20 12:56:10 America/Chicago
        Only update state file if not already up to date.
 0.605     2013-04-12 11:09:30 America/Chicago

--- a/dist.ini
+++ b/dist.ini
@@ -1,14 +1,14 @@
 name    = cPanel-TaskQueue
-version = 0.606
+version = 0.700
 author  = cPanel, Inc. <cpan@cpanel.net>
 license = Perl_5
 copyright_holder = cPanel, Inc.
 
 [@Basic]
 
-[ModuleBuild]
-[DualBuilders]
-prefer = make
+;[ModuleBuild]
+;[DualBuilders]
+;prefer = make
 [PkgVersion]
 [NextRelease]
 [PodSyntaxTests]

--- a/lib/cPanel/StateFile.pod
+++ b/lib/cPanel/StateFile.pod
@@ -5,7 +5,7 @@ cPanel::StateFile - Standardize the handling of file-based state data.
 
 =head1 VERSION
 
-This document describes cPanel::StateFile 0.606
+This document describes cPanel::StateFile 0.700
 
 =head1 SYNOPSIS
 

--- a/lib/cPanel/StateFile/FileLocker.pod
+++ b/lib/cPanel/StateFile/FileLocker.pod
@@ -6,7 +6,7 @@ cPanel::StateFile::FileLocker - Lock and unlock files using C<flock>.
 
 =head1 VERSION
 
-This document describes cPanel::StateFile::FileLocker version 0.606
+This document describes cPanel::StateFile::FileLocker version 0.700
 
 
 =head1 SYNOPSIS

--- a/lib/cPanel/TaskQueue.pm
+++ b/lib/cPanel/TaskQueue.pm
@@ -651,6 +651,21 @@ my $taskqueue_uuid = 'TaskQueue';
         };
     }
 
+    sub delete_all_unprocessed_tasks {
+        my ($self) = @_;
+        my $guard = $self->{disk_state}->synch();
+
+        # Empty the deferral and waiting queues. Can't change processing list,
+        # those tasks are actually in progress.
+        my $count = @{ $self->{deferral_queue} };
+        $self->{deferral_queue} = [];
+        $count += @{ $self->{queue_waiting} };
+        $self->{queue_waiting} = [];
+        $guard->update_file();
+
+        return $count;
+    }
+
     # ---------------------------------------------------------------
     #  Private Methods.
 
@@ -847,7 +862,7 @@ __PACKAGE__->register_task_processor( 'noop', sub { } );
 
 __END__
 
-Copyright (c) 2010, cPanel, Inc. All rights reserved.
+Copyright (c) 2014, cPanel, Inc. All rights reserved.
 
 This module is free software; you can redistribute it and/or
 modify it under the same terms as Perl itself. See L<perlartistic>.

--- a/lib/cPanel/TaskQueue.pod
+++ b/lib/cPanel/TaskQueue.pod
@@ -5,7 +5,7 @@ cPanel::TaskQueue - FIFO queue of tasks to perform
 
 =head1 VERSION
 
-This document describes cPanel::TaskQueue version 0.606
+This document describes cPanel::TaskQueue version 0.700
 
 =head1 SYNOPSIS
 
@@ -176,6 +176,16 @@ This method does not return until all tasks currently being processed in the
 background are completed. It is most useful to call as part of shutdown of the
 program that processes the queue. While waiting for processing to complete,
 this method does not start any new tasks out of the queue.
+
+=item $q->delete_all_unprocessed_tasks()
+
+This method deletes all tasks in the deferred or waiting state from the
+C<cPanel::TaskQueue>. It does nothing with the Tasks that are currently being
+processed.
+
+I<Warning>: This is probably not a very good idea. However, there may be a
+circumstance where we need to throw away everything that is in the queue and
+this method provides that ability.
 
 =back
 

--- a/lib/cPanel/TaskQueue/ChildProcessor.pod
+++ b/lib/cPanel/TaskQueue/ChildProcessor.pod
@@ -5,7 +5,7 @@ cPanel::TaskQueue::ChildProcessor - Processes an individual task from the cPanel
 
 =head1 VERSION
 
-This document describes cPanel::TaskQueue::ChildProcessor version 0.606.
+This document describes cPanel::TaskQueue::ChildProcessor version 0.700.
 
 =head1 SYNOPSIS
 

--- a/lib/cPanel/TaskQueue/Ctrl.pod
+++ b/lib/cPanel/TaskQueue/Ctrl.pod
@@ -5,7 +5,7 @@ cPanel::TaskQueue::Ctrl - A text-based interface for controlling a TaskQueue
 
 =head1 VERSION
 
-This document describes cPanel::TaskQueue::Ctrl version 0.606
+This document describes cPanel::TaskQueue::Ctrl version 0.700
 
 
 =head1 SYNOPSIS
@@ -31,7 +31,7 @@ corrupt the queue making further execution of tasks impossible. This module
 provides the tools needed to allow safe manipulation of a queue and associated
 scheduler.
 
-As a general rule, most users will find the C<taskqueuectrl> script much more
+As a general rule, most users will find the C<taskqueuectl> script much more
 useful than using this module directly. However, the module is provided to
 allow new tools to be built more easily.
 
@@ -229,6 +229,33 @@ the active queue.
 
 If neither C<scheduled> or C<waiting> are supplied, the routine acts as if both
 were supplied.
+
+=head2 flush_scheduled_tasks( $ctrl, $fh, $queue, $sched )
+
+Flushes all scheduled tasks to the waiting queue regardless of whether the scheduled
+times have been reached. Prints a message reporting the number of flushed tasks to
+the C<$fh> file handle.
+
+=head2 delete_unprocessed_tasks( $ctrl, $fh, $queue, $sched, @args )
+
+Deletes tasks which are not yet being processed. Tasks that are currently being
+processed are not deleted. The tasks to be deleted are determined by the supplied
+arguments. Supported arguments are:
+
+=over 4
+
+=item waiting
+
+If this argument is supplied, waiting and/or deferred tasks are deleted.
+
+=item scheduled
+
+If this argument is supplied, scheduled tasks are deleted.
+
+=back
+
+If neither C<waiting> or C<scheduled> are supplied, all non-processed tasks are
+deleted.
 
 =head1 DIAGNOSTICS
 

--- a/lib/cPanel/TaskQueue/PluginManager.pod
+++ b/lib/cPanel/TaskQueue/PluginManager.pod
@@ -5,7 +5,7 @@ cPanel::TaskQueue::PluginManager - Supplies support for loading the Queue task p
 
 =head1 VERSION
 
-This document describes C<cPanel::TaskQueue::PluginManager> version 0.606.
+This document describes C<cPanel::TaskQueue::PluginManager> version 0.700.
 
 =head1 SYNOPSIS
 

--- a/lib/cPanel/TaskQueue/Processor.pod
+++ b/lib/cPanel/TaskQueue/Processor.pod
@@ -5,7 +5,7 @@ cPanel::TaskQueue::Processor - Processes an individual task from the cPanel::Tas
 
 =head1 VERSION
 
-This document describes cPanel::TaskQueue::Processor version 0.606.
+This document describes cPanel::TaskQueue::Processor version 0.700.
 
 =head1 SYNOPSIS
 

--- a/lib/cPanel/TaskQueue/Scheduler.pod
+++ b/lib/cPanel/TaskQueue/Scheduler.pod
@@ -5,7 +5,7 @@ cPanel::TaskQueue::Scheduler - Priority queue of Tasks to Queue at some time in 
 
 =head1 VERSION
 
-This document describes cPanel::TaskQueue::Scheduler version 0.606.
+This document describes cPanel::TaskQueue::Scheduler version 0.700.
 
 =head1 SYNOPSIS
 
@@ -209,6 +209,27 @@ it's I<uuid>, so don't expect the C<uuid> from the scheduler to have any relatio
 to the C<uuid> of the same task in the C<TaskQueue>.
 
 Returns the number of tasks processed, C<0> if there were no tasks to process.
+
+=item $s->flush_all_tasks( $queue )
+
+This method takes all Tasks, whether or not they have reached their schedule
+time and passes the to the C<queue_task> method of the supplied I<queue>
+object. No object is removed from the scheduler unless C<queue_task> runs
+without an exception.
+
+Returns a list of the C<uuid>s of all tasks that are scheduled.
+
+I<Warning>: This is almost certainly a bad idea. But, there are a few cases where
+the scheduling may need to be overridden.
+
+=item $s->delete_all_tasks( $queue )
+
+This method removes all Tasks from the scheduler without any processing.
+
+Returns a count of the number of tasks that were removed.
+
+I<Warning>: This is almost certainly a bad idea. But, there are a few cases where
+the scheduled tasks may need to be discarded.
 
 =back
 

--- a/lib/cPanel/TaskQueue/Task.pod
+++ b/lib/cPanel/TaskQueue/Task.pod
@@ -5,7 +5,7 @@ cPanel::TaskQueue::Task - Objects representing the task concept.
 
 =head1 VERSION
 
-This document describes cPanel::TaskQueue::Task version 0.606.
+This document describes cPanel::TaskQueue::Task version 0.700.
 
 =head1 SYNOPSIS
 

--- a/t/mocks/MockQueue.pm
+++ b/t/mocks/MockQueue.pm
@@ -1,0 +1,38 @@
+package MockQueue;
+
+use warnings;
+use strict;
+
+sub new {
+    my ($class) = @_;
+    return bless [], $class;
+}
+
+sub queue_task {
+    my ($self, $task) = @_;
+
+    push @{$self}, $task;
+    return $task->uuid;
+}
+
+sub clear_tasks {
+    my ($self) = @_;
+    @{$self} = ();
+    return;
+}
+
+sub get_tasks {
+    my ($self) = @_;
+    return @{$self};
+}
+
+1;
+
+=head1 NAME
+
+MockQueue - Mock the interface for a Queue object to allow Scheduler processing.
+
+=head1 DESCRIPTION
+
+This is a mocked queue object that basically supports the C<queue_task> method.
+It also includes the ability to clear and retrieve the task objects.

--- a/t/taskqueue_scheduler.t
+++ b/t/taskqueue_scheduler.t
@@ -8,12 +8,15 @@
 #  variable CPANEL_SLOW_TESTS set.
 
 use strict;
+use warnings;
 use FindBin;
 use lib "$FindBin::Bin/mocks";
 use File::Path ();
 
-use Test::More tests => 85;
+use Test::More tests => 91;
+use Test::Exception;
 use cPanel::TaskQueue::Scheduler;
+use MockQueue;
 
 my $tmpdir   = './tmp';
 my $statedir = $tmpdir;
@@ -22,8 +25,8 @@ my $statedir = $tmpdir;
 cleanup();
 File::Path::mkpath($tmpdir) or die "Unable to create tmpdir: $!";
 
-eval { cPanel::TaskQueue::Scheduler->new( { state_dir => $statedir } ); };
-like( $@, qr/scheduler name/, 'Must supply a name.' );
+throws_ok { cPanel::TaskQueue::Scheduler->new( { state_dir => $statedir } ); } qr/scheduler name/,
+    'Must supply a name.';
 
 my $sched = cPanel::TaskQueue::Scheduler->new( { name => 'tasks', state_dir => $statedir } );
 isa_ok( $sched, 'cPanel::TaskQueue::Scheduler', 'Correct object built.' );
@@ -32,14 +35,10 @@ isa_ok( $sched, 'cPanel::TaskQueue::Scheduler', 'Correct object built.' );
 is( $sched->_state_file, "$statedir/tasks_sched.stor", 'State file has correct form.' );
 
 # Check failures to schedule
-eval { $sched->schedule_task(); };
-like( $@, qr/empty command/, 'Must supply the command.' );
-eval { $sched->schedule_task( '   ', { delay_seconds => 5 } ); };
-like( $@, qr/empty command/, 'Must supply a non-empty command.' );
-eval { $sched->schedule_task('noop 0'); };
-like( $@, qr/not a hash ref/, 'Must supply the time hash.' );
-eval { $sched->schedule_task( 'noop 0', 10 ); };
-like( $@, qr/not a hash ref/, 'Second arg must be a hash ref' );
+throws_ok { $sched->schedule_task(); } qr/empty command/, 'Must supply the command.';
+throws_ok { $sched->schedule_task( '   ', { delay_seconds => 5 } ); } qr/empty command/, 'Must supply a non-empty command.';
+throws_ok { $sched->schedule_task('noop 0'); } qr/not a hash ref/, 'Must supply the time hash.';
+throws_ok { $sched->schedule_task( 'noop 0', 10 ); } qr/not a hash ref/, 'Second arg must be a hash ref';
 
 # Check ability to schedule
 my @qid;
@@ -143,6 +142,42 @@ ok( $sched->seconds_until_next_task() <= 0, 'Scheduled right now (or in the last
 
 cleanup();
 
+{
+    my $label = 'flush_all_tasks';
+    # Start with clean state
+    File::Path::mkpath($tmpdir) or die "$label: Unable to create tmpdir: $!";
+    my $sched = cPanel::TaskQueue::Scheduler->new( { name => 'tasks', state_dir => $statedir } );
+    my $time = time + 10;
+    my @qid;
+    foreach my $cnt ( 1 .. 4 ) {
+        push @qid, $sched->schedule_task( "noop $cnt", { at_time => $time+$cnt } );
+    }
+    is( $sched->how_many_scheduled(), 4, "$label: correct number tasks scheduled." );
+    my $queue = MockQueue->new();
+    my @flushed = $sched->flush_all_tasks( $queue );
+    is( @flushed, 4, "$label: All tasks flushed." );
+    is( $sched->how_many_scheduled(), 0, "$label: No scheduled tasks remain" );
+
+    cleanup();
+}
+
+{
+    my $label = 'delete_all_tasks';
+    # Start with clean state
+    File::Path::mkpath($tmpdir) or die "$label: Unable to create tmpdir: $!";
+    my $sched = cPanel::TaskQueue::Scheduler->new( { name => 'tasks', state_dir => $statedir } );
+    my $time = time + 10;
+    my @qid;
+    foreach my $cnt ( 1 .. 4 ) {
+        push @qid, $sched->schedule_task( "noop $cnt", { at_time => $time+$cnt } );
+    }
+    is( $sched->how_many_scheduled(), 4, "$label: correct number tasks scheduled." );
+    is( $sched->delete_all_tasks(), 4, "$label: all tasks deleted" );
+    is( $sched->how_many_scheduled(), 0, "$label: No scheduled tasks remain" );
+
+    cleanup();
+}
+
 sub insert_tasks {
     my $s     = shift;
     my $label = shift;
@@ -153,6 +188,7 @@ sub insert_tasks {
         ok( $qid, "$label [$i]: scheduled successfully" );
         ++$i;
     }
+    return;
 }
 
 sub remove_and_check_tasks {
@@ -166,6 +202,7 @@ sub remove_and_check_tasks {
         ok( $s->unschedule_task( $first->uuid() ), "$label [$i]: Remove queue front." );
         ++$i;
     }
+    return;
 }
 
 sub check_task_insertion {
@@ -174,9 +211,11 @@ sub check_task_insertion {
 
     insert_tasks( $s, $label, @_ );
     remove_and_check_tasks( $s, $label, @_ );
+    return;
 }
 
 # Clean up after myself
 sub cleanup {
     File::Path::rmtree($tmpdir) if -d $tmpdir;
+    return;
 }


### PR DESCRIPTION
Clean up critic issues and fix optional serial param.
Add support for flush_all_tasks and delete_all_tasks to scheduler.
Add support for deleting tasks from the queues to taskqueue.
Update the Changes file.
Update version number in dist.ini.
Drop the ability to do Module::Build in dist.ini.
Add taskqueuectl support for flushing scheduled tasks.
Add taskqueuectl support for deleting unprocessed tasks.
Update tests to match new code.
On any tests that were changed replace hokey exception testing with
Test::Exception calls.

Based on discussion with Brian and Todd, I've added the flushing support. We had also talked a little about just being able to delete tasks instead of flushing them to be processed. Assuming that the flushing approach might not cover everything, I implemented both pieces of functionality. This prevents us from needed to make another release if the first idea is not enough.
