### PR TITLE
Ensure that 'lone' deferred tasks are processed properly.

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -1,5 +1,5 @@
 name    = cPanel-TaskQueue
-version = 0.606
+version = 0.607
 author  = cPanel, Inc. <cpan@cpanel.net>
 license = Perl_5
 copyright_holder = cPanel, Inc.
@@ -21,3 +21,6 @@ filenames = dist.ini
 
 [AutoPrereqs]
 skip = ^Mock|Fake|^English$
+
+[Prereqs / TestRequires]
+YAML::Syck = 0

--- a/lib/cPanel/TaskQueue.pm
+++ b/lib/cPanel/TaskQueue.pm
@@ -554,6 +554,7 @@ my $taskqueue_uuid = 'TaskQueue';
             # Check for deferrals.
             if ( $processor->is_task_deferred( $task, $self->{defer_obj} ) ) {
                 unshift @{ $self->{deferral_queue} }, $task;
+                push @{ $self->{processing_list} }, $task;
                 $task = undef;
             }
         }

--- a/t/taskqueue_task_deferrable.t
+++ b/t/taskqueue_task_deferrable.t
@@ -119,7 +119,7 @@ sub clear_process_wait { unlink "$state_dir/flag"; }
 
     is( $queue->how_many_queued(),     0, "$label (2 step): queue count is correct" );
     is( $queue->how_many_deferred(),   3, "$label (2 step): deferred count is correct" );
-    is( $queue->how_many_in_process(), 1, "$label (2 step): process count is correct" );
+    is( $queue->how_many_in_process(), 4, "$label (2 step): process count is correct" );
 
     clear_process_wait();
     sleep( 1 ); # Clear the processing task
@@ -143,7 +143,7 @@ sub clear_process_wait { unlink "$state_dir/flag"; }
 
     is( $queue->how_many_queued(),     0, "$label (3 step): queue count is correct" );
     is( $queue->how_many_deferred(),   2, "$label (3 step): deferred count is correct" );
-    is( $queue->how_many_in_process(), 1, "$label (3 step): process count is correct" );
+    is( $queue->how_many_in_process(), 3, "$label (3 step): process count is correct" );
 
     clear_process_wait();
     File::Path::rmtree( $state_dir );
@@ -183,7 +183,7 @@ sub clear_process_wait { unlink "$state_dir/flag"; }
 
     is( $queue->how_many_queued(),     0, "$label (2 step): queue count is correct" );
     is( $queue->how_many_deferred(),   2, "$label (2 step): deferred count is correct" );
-    is( $queue->how_many_in_process(), 2, "$label (2 step): process count is correct" );
+    is( $queue->how_many_in_process(), 4, "$label (2 step): process count is correct" );
 
     clear_process_wait();
     File::Path::rmtree( $state_dir );


### PR DESCRIPTION
Add 'deferred' tasks in the list the processing tasks, to ensure that
the 'has_work_to_do' calls return valid information.

Please see internal case 136069 for more details.
