### PR TITLE
use File::Temp for unit tests

### DIFF
--- a/t/statefile_bad_call_unlocked.t
+++ b/t/statefile_bad_call_unlocked.t
@@ -1,27 +1,25 @@
 #!/usr/bin/perl
 
+use strict;
+use warnings;
+
 use FindBin;
 use lib "$FindBin::Bin/mocks";
 
 use Test::More tests => 5;
 use File::Path ();
-
-use strict;
-use warnings;
+use File::Temp;
 
 use cPanel::StateFile;
 use MockCacheable;
 
-my $tmpdir   = './tmp';
+my $tmpdir   = File::Temp->newdir();
 my $dir      = "$tmpdir/state_test";
 my $file     = "$dir/state_dir/state_file";
 my $lockname = "$file.lock";
 
-cleanup();
-File::Path::mkpath($tmpdir) or die "Unable to create temporary directory: $!";
-
 my $mock_obj = MockCacheable->new;
-my $state = cPanel::StateFile->new( { state_file => $file, data_obj => $mock_obj } );
+my $state    = cPanel::StateFile->new( { state_file => $file, data_obj => $mock_obj } );
 
 {
     my $guard = $state->synch();
@@ -55,11 +53,4 @@ my $state = cPanel::StateFile->new( { state_file => $file, data_obj => $mock_obj
         );
     };
     like( $@, qr/test exception/, 'Exceptions are passed out of call correctly.' );
-}
-
-cleanup();
-
-# Discard temporary files that we don't need any more.
-sub cleanup {
-    File::Path::rmtree($tmpdir) if -d $tmpdir;
 }

--- a/t/taskqueue_bad_statefile.t
+++ b/t/taskqueue_bad_statefile.t
@@ -6,16 +6,13 @@ use strict;
 use warnings;
 use FindBin;
 use File::Path ();
+use File::Temp ();
 use lib "$FindBin::Bin/mocks";
 
 use cPanel::TaskQueue ( -logger => 'cPanel::FakeLogger' );
 
-my $tmpdir   = './tmp';
-my $statedir = "$tmpdir/state_test";
-
-# In case the last test did not succeed.
-cleanup();
-File::Path::mkpath($statedir);
+my ( $tmpdir, $statedir );
+setup();
 
 {
     open( my $fh, '>', "$statedir/tasks_queue.stor" );
@@ -34,8 +31,7 @@ File::Path::mkpath($statedir);
     );
 }
 
-cleanup();
-File::Path::mkpath($statedir);
+setup();
 
 {
     use Storable ();
@@ -51,9 +47,11 @@ File::Path::mkpath($statedir);
     ok( -e "$statedir/tasks_queue.stor.broken", 'Bad file moved out of the way.' );
 }
 
-cleanup();
-
 # Clean up after myself
-sub cleanup {
-    File::Path::rmtree($tmpdir);
+sub setup {
+    $tmpdir   = File::Temp->newdir();
+    $statedir = "$tmpdir/state_test";
+    File::Path::mkpath($statedir);
+
+    return;
 }

--- a/t/taskqueue_bad_yaml_statefile.t
+++ b/t/taskqueue_bad_yaml_statefile.t
@@ -6,16 +6,13 @@ use strict;
 use warnings;
 use FindBin;
 use File::Path ();
+use File::Temp ();
 use lib "$FindBin::Bin/mocks";
 
 use cPanel::TaskQueue ( -logger => 'cPanel::FakeLogger', -serializer => 'cPanel::TQSerializer::YAML' );
 
-my $tmpdir   = './tmp';
-my $statedir = "$tmpdir/state_test";
-
-# In case the last test did not succeed.
-cleanup();
-File::Path::mkpath($statedir);
+my ( $tmpdir, $statedir );
+setup();
 
 {
     open( my $fh, '>', "$statedir/tasks_queue.yaml" );
@@ -34,8 +31,7 @@ File::Path::mkpath($statedir);
     );
 }
 
-cleanup();
-File::Path::mkpath($statedir);
+setup();
 
 {
     use YAML::Syck ();
@@ -51,9 +47,12 @@ File::Path::mkpath($statedir);
     ok( -e "$statedir/tasks_queue.yaml.broken", 'Bad file moved out of the way.' );
 }
 
-cleanup();
+exit;
 
-# Clean up after myself
-sub cleanup {
-    File::Path::rmtree($tmpdir);
+sub setup {
+    $tmpdir   = File::Temp->newdir();
+    $statedir = "$tmpdir/state_test";
+    File::Path::mkpath($statedir);
+
+    return;
 }

--- a/t/taskqueue_find_commands.t
+++ b/t/taskqueue_find_commands.t
@@ -4,17 +4,14 @@ use strict;
 use FindBin;
 use lib "$FindBin::Bin/mocks";
 use File::Path ();
+use File::Temp ();
 
 use Test::More tests => 10;
 use cPanel::TaskQueue;
 use cPanel::TaskQueue::PluginManager;
 
-my $tmpdir   = './tmp';
+my $tmpdir   = File::Temp->newdir();
 my $statedir = "$tmpdir/state_test";
-
-# In case the last test did not succeed.
-cleanup();
-File::Path::mkpath($tmpdir) or die "Unable to create tmpdir: $!";
 
 cPanel::TaskQueue::PluginManager::load_all_plugins(
     directories => ["$FindBin::Bin/mocks"],
@@ -57,10 +54,4 @@ is( $queue->how_many_queued(), scalar(@qids), 'Commands queued for further testi
     is( $queue->find_command('hello')->uuid(), $qids[5], 'Found command that is a substring of another' );
     my @tasks = $queue->find_commands('hello');
     is_deeply( [ map { $_->uuid } @tasks ], [ $qids[5] ], 'Found only the substring command.' );
-}
-
-cleanup();
-
-sub cleanup {
-    File::Path::rmtree($tmpdir);
 }

--- a/t/taskqueue_find_task.t
+++ b/t/taskqueue_find_task.t
@@ -7,16 +7,13 @@ use strict;
 use FindBin;
 use lib "$FindBin::Bin/mocks";
 use File::Path ();
+use File::Temp ();
 
 use Test::More tests => 20;
 use cPanel::TaskQueue;
 
-my $tmpdir   = './tmp';
+my $tmpdir   = File::Temp->newdir();
 my $statedir = "$tmpdir/statedir";
-
-# In case the last test did not succeed.
-cleanup();
-File::Path::mkpath($tmpdir) or die "Unable to create tmpdir: $!";
 
 {
 
@@ -82,12 +79,5 @@ ok( !$queue->find_command('xyzzy'), 'Did not find non-existant command.' );
     my $tid = $queue->queue_task('noop 1234');
     $queue->unqueue_task($tid);
     ok( !$queue->find_task($tid), 'Can not find task that is not isn queue.' );
-}
-
-cleanup();
-
-# Clean up after myself
-sub cleanup {
-    File::Path::rmtree($tmpdir) if -d $tmpdir;
 }
 

--- a/t/taskqueue_long_processes.t
+++ b/t/taskqueue_long_processes.t
@@ -10,11 +10,12 @@ use strict;
 use FindBin;
 use lib "$FindBin::Bin/mocks";
 use File::Path ();
+use File::Temp ();
 
 use Test::More tests => 34;
 use cPanel::TaskQueue;
 
-my $tmpdir   = './tmp';
+my $tmpdir   = File::Temp->newdir();
 my $statedir = "$tmpdir/statedir";
 
 {
@@ -31,10 +32,6 @@ my $statedir = "$tmpdir/statedir";
 }
 
 {
-    # In case the last test did not succeed.
-    cleanup();
-    File::Path::mkpath($statedir);
-
     cPanel::TaskQueue->register_task_processor( 'sleep', SleepTask->new() );
 
     my $queue = cPanel::TaskQueue->new( { name => 'tasks', state_dir => $statedir, max_running => 5 } );
@@ -79,10 +76,5 @@ my $statedir = "$tmpdir/statedir";
     ok( !$queue->has_work_to_do(), 'no outstanding tasks' );
     is( $queue->how_many_in_process(), 0, 'no more in process' );
 
-    cleanup();
 }
 
-# Clean up after myself
-sub cleanup {
-    File::Path::rmtree($tmpdir);
-}

--- a/t/taskqueue_missing_dir.t
+++ b/t/taskqueue_missing_dir.t
@@ -8,23 +8,11 @@ use strict;
 use Test::More tests => 2;
 use cPanel::TaskQueue;
 use File::Path ();
+use File::Temp ();
 
-my $tmpdir      = './tmp';
+my $tmpdir      = File::Temp->newdir();
 my $missing_dir = "$tmpdir/task_queue_test";
-
-# In case the last test did not succeed.
-cleanup();
-File::Path::mkpath($tmpdir) or die "Unable to create tmpdir: $!";
 
 # Test queue directory creation.
 ok( cPanel::TaskQueue->new( { name => 'tasks', state_dir => $missing_dir } ), 'Cache created with missing dir' );
-ok( -d $missing_dir, 'created the state directory' );
-cleanup();
-
-# Clean up after myself
-sub cleanup {
-    foreach my $file ( 'tasks_queue.yaml', 'tasks_queue.yaml.lock' ) {
-        unlink "$missing_dir/$file" if -e "$missing_dir/$file";
-    }
-    rmdir $missing_dir if -d $missing_dir;
-}
+ok( -d $missing_dir,                                                          'created the state directory' );

--- a/t/taskqueue_parameter_changes.t
+++ b/t/taskqueue_parameter_changes.t
@@ -9,16 +9,13 @@ use strict;
 use FindBin;
 use lib "$FindBin::Bin/mocks";
 use File::Path ();
+use File::Temp ();
 
 use Test::More tests => 15;
 use cPanel::TaskQueue;
 
-my $tmpdir   = './tmp';
+my $tmpdir   = File::Temp->newdir();
 my $statedir = "$tmpdir/statedir";
-
-# In case the last test did not succeed.
-cleanup();
-File::Path::mkpath($statedir);
 
 # Set all parameters to non-defaults.
 my $q1 = cPanel::TaskQueue->new(
@@ -60,9 +57,3 @@ is( $q1->get_max_timeout(),           16,  'Original updated max timeout from fi
 is( $q1->get_max_running(),           17,  'Original updated max in process from file' );
 is( $q1->get_default_child_timeout(), 742, 'Original updated default child timeout from file' );
 
-cleanup();
-
-# Clean up after myself
-sub cleanup {
-    File::Path::rmtree($tmpdir);
-}

--- a/t/taskqueue_pausing.t
+++ b/t/taskqueue_pausing.t
@@ -4,16 +4,13 @@ use strict;
 use FindBin;
 use lib "$FindBin::Bin/mocks";
 use File::Path ();
+use File::Temp ();
 
 use Test::More tests => 15;
 use cPanel::TaskQueue;
 
-my $tmpdir   = './tmp';
+my $tmpdir   = File::Temp->newdir();
 my $statedir = "$tmpdir/state_test";
-
-# In case the last test did not succeed.
-cleanup();
-File::Path::mkpath($tmpdir) or die "Unable to create tmpdir: $!";
 
 # Create the real TaskQueue
 my $queue = cPanel::TaskQueue->new( { name => 'tasks', state_dir => $statedir } );
@@ -44,11 +41,4 @@ ok( !$queue->is_task_queued($qid), 'no longer found in queue' );
     $queue2->resume_processing;
     ok( !$queue2->is_paused, "$label: TaskQueue2 is unpaused." );
     ok( !$queue->is_paused,  "$label: TaskQueue is unpaused." );
-}
-
-cleanup();
-
-# Clean up after myself
-sub cleanup {
-    File::Path::rmtree($tmpdir);
 }

--- a/t/taskqueue_register_processors.t
+++ b/t/taskqueue_register_processors.t
@@ -7,14 +7,12 @@ use strict;
 use FindBin;
 use lib "$FindBin::Bin/mocks";
 use File::Path ();
+use File::Temp ();
 
 use Test::More tests => 20;
 use cPanel::TaskQueue;
 
-my $tmpdir = './tmp';
-
-# Make sure we are clean to start with.
-File::Path::rmtree($tmpdir);
+my $tmpdir   = File::Temp->newdir();
 my $statedir = $tmpdir;
 
 eval { cPanel::TaskQueue->register_task_processor(); };
@@ -47,9 +45,9 @@ ok(
 );
 
 ok( my $qid4 = $queue->queue_task('doit a b c'), 'Added a task with new command.' );
-ok( $queue->process_next_task(),        'Task processed immediately' );
-ok( !$queue->is_task_queued($qid4),     'Task is not queued.' );
-ok( !$queue->is_task_processing($qid4), 'Task is not processing.' );
+ok( $queue->process_next_task(),                 'Task processed immediately' );
+ok( !$queue->is_task_queued($qid4),              'Task is not queued.' );
+ok( !$queue->is_task_processing($qid4),          'Task is not processing.' );
 is( $times_executed, 1, 'doit code actually executed.' );
 
 {
@@ -84,9 +82,3 @@ like( $@, qr/Missing command/, 'Must supply a non-empty command to unregister.' 
 eval { cPanel::TaskQueue->unregister_task_processor('xyzzy'); };
 like( $@, qr/not registered/, 'Command must have been registered.' );
 
-cleanup();
-
-# Clean up after myself
-sub cleanup {
-    File::Path::rmtree($tmpdir);
-}

--- a/t/taskqueue_scheduler_bad_statefile.t
+++ b/t/taskqueue_scheduler_bad_statefile.t
@@ -7,15 +7,12 @@ use warnings;
 use FindBin;
 use lib "$FindBin::Bin/mocks";
 use File::Path ();
+use File::Temp ();
 
 use cPanel::TaskQueue::Scheduler ( -logger => 'cPanel::FakeLogger' );
 
-my $tmpdir   = './tmp';
-my $statedir = "$tmpdir/statedir";
-
-# In case the last test did not succeed.
-cleanup();
-File::Path::mkpath($statedir);
+my ( $tmpdir, $statedir );
+setup();
 
 {
     open( my $fh, '>', "$statedir/tasks_sched.stor" ) or die "Unable to create file: $!\n";
@@ -34,8 +31,7 @@ File::Path::mkpath($statedir);
     );
 }
 
-cleanup();
-File::Path::mkpath($statedir);
+setup();
 
 {
     use Storable ();
@@ -51,9 +47,12 @@ File::Path::mkpath($statedir);
     ok( -e "$statedir/tasks_sched.stor.broken", 'Bad file moved out of the way.' );
 }
 
-cleanup();
+exit;
 
-# Clean up after myself
-sub cleanup {
-    File::Path::rmtree($tmpdir) if -d $tmpdir;
+sub setup {
+    $tmpdir   = File::Temp->newdir();
+    $statedir = "$tmpdir/state_test";
+    File::Path::mkpath($statedir);
+
+    return;
 }

--- a/t/taskqueue_scheduler_bad_yaml_statefile.t
+++ b/t/taskqueue_scheduler_bad_yaml_statefile.t
@@ -7,15 +7,13 @@ use warnings;
 use FindBin;
 use lib "$FindBin::Bin/mocks";
 use File::Path ();
+use File::Temp ();
 
 use cPanel::TaskQueue::Scheduler ( -logger => 'cPanel::FakeLogger', -serializer => 'cPanel::TQSerializer::YAML' );
 
-my $tmpdir   = './tmp';
-my $statedir = "$tmpdir/statedir";
+my ( $tmpdir, $statedir );
 
-# In case the last test did not succeed.
-cleanup();
-File::Path::mkpath($statedir);
+setup();
 
 {
     open( my $fh, '>', "$statedir/tasks_sched.yaml" ) or die "Unable to create file: $!\n";
@@ -34,8 +32,7 @@ File::Path::mkpath($statedir);
     );
 }
 
-cleanup();
-File::Path::mkpath($statedir);
+setup();
 
 {
     use YAML::Syck ();
@@ -51,9 +48,12 @@ File::Path::mkpath($statedir);
     ok( -e "$statedir/tasks_sched.yaml.broken", 'Bad file moved out of the way.' );
 }
 
-cleanup();
+exit;
 
 # Clean up after myself
-sub cleanup {
-    File::Path::rmtree($tmpdir) if -d $tmpdir;
+sub setup {
+    $tmpdir   = File::Temp->newdir();
+    $statedir = "$tmpdir/state_test";
+    File::Path::mkpath($statedir);
+    return;
 }

--- a/t/taskqueue_scheduler_token.t
+++ b/t/taskqueue_scheduler_token.t
@@ -6,14 +6,12 @@ use strict;
 use warnings;
 
 use File::Path ();
+use File::Temp ();
+
 use cPanel::TaskQueue::Scheduler();
 
-my $tmpdir   = './tmp';
+my $tmpdir   = File::Temp->newdir();
 my $statedir = "$tmpdir/taskqueue";
-
-# In case the last test did not succeed.
-cleanup();
-File::Path::mkpath($tmpdir) or die "Unable to create tmpdir: $!";
 
 my $sched = cPanel::TaskQueue::Scheduler->new( { name => 'tasks', state_dir => $statedir } );
 
@@ -49,9 +47,3 @@ like( $@, qr/Invalid token./, 'Name does not match' );
 eval { cPanel::TaskQueue::Scheduler->new( { token => 'tqsched1:|:tasks|:fred_sched.stor' } ); };
 like( $@, qr/Invalid token./, 'File does not match' );
 
-cleanup();
-
-# Clean up after myself
-sub cleanup {
-    File::Path::rmtree($tmpdir) if -e $tmpdir;
-}

--- a/t/taskqueue_scheduler_token_yaml.t
+++ b/t/taskqueue_scheduler_token_yaml.t
@@ -6,14 +6,11 @@ use strict;
 use warnings;
 
 use File::Path ();
+use File::Temp ();
 use cPanel::TaskQueue::Scheduler( '-serializer' => 'cPanel::TQSerializer::YAML' );
 
-my $tmpdir   = './tmp';
+my $tmpdir   = File::Temp->newdir();
 my $statedir = "$tmpdir/taskqueue";
-
-# In case the last test did not succeed.
-cleanup();
-File::Path::mkpath($tmpdir) or die "Unable to create tmpdir: $!";
 
 my $sched = cPanel::TaskQueue::Scheduler->new( { name => 'tasks', state_dir => $statedir } );
 
@@ -49,9 +46,3 @@ like( $@, qr/Invalid token./, 'Name does not match' );
 eval { cPanel::TaskQueue::Scheduler->new( { token => 'tqsched1:|:tasks|:fred_sched.yaml' } ); };
 like( $@, qr/Invalid token./, 'File does not match' );
 
-cleanup();
-
-# Clean up after myself
-sub cleanup {
-    File::Path::rmtree($tmpdir) if -e $tmpdir;
-}


### PR DESCRIPTION
This is avoiding to take care of the cleanup
manually and allow to run tests in parallel.